### PR TITLE
Fixed YAlignment::setBackgroundPixmap

### DIFF
--- a/src/YQAlignment.cc
+++ b/src/YQAlignment.cc
@@ -26,6 +26,7 @@
 #define YUILogComponent "qt-ui"
 #include <yui/YUILog.h>
 #include <qpixmap.h>
+#include <QPainter>
 #include "YQAlignment.h"
 
 using std::string;
@@ -35,7 +36,7 @@ YQAlignment::YQAlignment( YWidget *	  	parent,
 			  YAlignmentType 	horAlign,
 			  YAlignmentType 	vertAlign )
     : QWidget( (QWidget *) parent->widgetRep() )
-    , YAlignment( parent, horAlign, vertAlign )
+    , YAlignment( parent, horAlign, vertAlign ), _pixmapFileName()
 {
     setWidgetRep( this );
 }
@@ -46,7 +47,7 @@ YQAlignment::YQAlignment( YWidget *	  	yParent,
 			  YAlignmentType 	horAlign,
 			  YAlignmentType 	vertAlign )
     : QWidget( qParent )
-    , YAlignment( yParent, horAlign, vertAlign )
+    , YAlignment( yParent, horAlign, vertAlign ), _pixmapFileName()
 {
     setWidgetRep( this );
 }
@@ -72,35 +73,22 @@ void YQAlignment::setSize( int newWidth, int newHeight )
     YAlignment::setSize( newWidth, newHeight );
 }
 
+void YQAlignment::paintEvent ( QPaintEvent * event )
+{
+  QPainter painter(this);
+  painter.drawPixmap(rect(), QPixmap(_pixmapFileName.c_str()));
+
+  QWidget::paintEvent(event);
+}
 
 void YQAlignment::setBackgroundPixmap( const std::string & pixmapFileName )
 {
-    std::string pixmapName = pixmapFileName;
+    _pixmapFileName = pixmapFileName;
 
-    YAlignment::setBackgroundPixmap( pixmapName );	// Prepend path etc.
-    pixmapName = YAlignment::backgroundPixmap();
+    YAlignment::setBackgroundPixmap( _pixmapFileName );	// Prepend path etc.
+    _pixmapFileName = YAlignment::backgroundPixmap();
 
-    if ( pixmapName.empty() )	// Delete any old background pixmap
-    {
-            QPalette pal = palette();
-            pal.setBrush(backgroundRole(), QBrush());
-            setPalette(pal);
-    }
-    else			// Set a new background pixmap
-    {
-	QPixmap pixmap( pixmapName.c_str() );
-
-	if ( pixmap.isNull() )
-	{
-	    yuiError() << "Can't load background pixmap \"" << pixmapName << "\"" << std::endl;
-	}
-	else
-	{
-            QPalette pal = palette();
-            pal.setBrush(backgroundRole(), QBrush(pixmap));
-            setPalette(pal);
-	}
-    }
+    this->update();
 }
 
 #include "YQAlignment.moc"

--- a/src/YQAlignment.h
+++ b/src/YQAlignment.h
@@ -86,6 +86,10 @@ public:
      **/
      virtual void setBackgroundPixmap( const std::string & pixmapFileName );
 
+protected:
+     std::string _pixmapFileName;
+     virtual void paintEvent ( QPaintEvent * event );
+
 };
 
 


### PR DESCRIPTION
following code does not work, background is ignored:
int main( int argc, char *_argv )
{
   YDialog    \* dialog        = YUI::widgetFactory()->createPopupDialog();
   YFrame_      frame         = YUI::widgetFactory()->createFrame(dialog, "Test frame");
   YLayoutBox \* hbox          = YUI::widgetFactory()->createHBox(frame);
   YFrame\*      lframe        = YUI::widgetFactory()->createFrame(hbox, "Left frame");
   YFrame\*      rframe        = YUI::widgetFactory()->createFrame(hbox, "Right frame");
   YLayoutBox \* vbox_rframe   = YUI::widgetFactory()->createVBox( rframe );
   YLayoutBox \* vbox   = YUI::widgetFactory()->createVBox( lframe );
   lframe->setWeight(YD_HORIZ, 25);
   rframe->setWeight(YD_HORIZ, 75);
   YAlignment _align = YUI::widgetFactory()->createAlignment( vbox, YAlignBegin, YAlignCenter);
   align->setBackgroundPixmap("/usr/share/indexhtml/images/logo_mageia.png");
   YUI::widgetFactory()->createLabel     ( align, "Hello, World!" );
   YEvent_ event = dialog->waitForEvent();  
   dialog->destroy();
}

My patch fixed it. Behaviour between gtk and qt is different though (adding my gtk patch).
