### PR TITLE
Use pkgconfig BuildRequires for Qt5 packages/Make libyui-qt library conflict libproxy1-config-kde4

### DIFF
--- a/libyui-qt.spec.in
+++ b/libyui-qt.spec.in
@@ -50,6 +50,7 @@ Requires:       lib@BASELIB@@SONAME_MAJOR@
 Provides:       lib@BASELIB@-qt = %{version}
 Provides:       yast2-qt = %{version}
 Obsoletes:      yast2-qt < 2.42.0
+Conflicts:      libproxy1-config-kde4
 
 Url:            @URL@
 Summary:        @SUMMARY@


### PR DESCRIPTION
Reduces number of needed packages for build
