### PR TITLE
Include sys/param.h instead of rpc/types.h for MAXHOSTNAMELEN,

### DIFF
--- a/src/YQUI.cc
+++ b/src/YQUI.cc
@@ -22,7 +22,7 @@
 
 /-*/
 
-#include <rpc/types.h>		// MAXHOSTNAMELEN
+#include <sys/param.h>		// MAXHOSTNAMELEN
 #include <dlfcn.h>
 #include <libintl.h>
 #include <algorithm>


### PR DESCRIPTION
we are not using RPC functions and sunrpc is deprecated in glibc.