### PR TITLE
Fixed Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: required
+# use the Ubuntu 16.04 image with kernel 4.15.0, the default is 14.04 which
+# contains too old kernel (4.4.0), libQt5Core requires 4.11.0 or newer
+# (find with "ldconfig -p | grep Qt5Core")
+dist: xenial
 language: bash
 services:
   - docker
@@ -8,4 +12,6 @@ before_install:
 script:
   # the "libyui-travis" script is included in the base libyui/devel image
   # see https://github.com/libyui/docker-devel/blob/master/libyui-travis
-  - docker run -it libyui-qt-image libyui-travis
+  # For some strage reason building the Qt resource pack requires
+  # extra system privileges (ugh??)
+  - docker run -it --privileged libyui-qt-image libyui-travis


### PR DESCRIPTION
- libQt5Core requires Linux kernel 4.11.0 or newer, switch to Ubuntu 16.04 image (the default is 14.04)
- the Docker uses the host kernel, that's why I could not reproduce locally... 
- Fixed also the `Cannot find file 'icons/computer.svg'` issue, for some strange reason the container needs `--privileged` option (WTF?)