### PR TITLE
New Widget: MenuBar (Qt UI Implementation)

### DIFF
--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -38,6 +38,7 @@ SET( ${TARGETLIB}_SOURCES
      YQLayoutBox.cc
      YQLogView.cc
      YQMainWinDock.cc
+     YQMenuBar.cc
      YQMenuButton.cc
      YQMultiLineEdit.cc
      YQMultiProgressMeter.cc
@@ -107,6 +108,7 @@ SET( ${TARGETLIB}_HEADERS
      YQLayoutBox.h
      YQLogView.h
      YQMainWinDock.h
+     YQMenuBar.h
      YQMenuButton.h
      YQMultiLineEdit.h
      YQMultiProgressMeter.h

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,11 +1,11 @@
 SET(VERSION_MAJOR "2")
-SET(VERSION_MINOR "53")
+SET(VERSION_MINOR "54")
 SET(VERSION_PATCH "0")
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is needed for the libyui-qt core ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
-SET( SONAME_MAJOR "12" )
+SET( SONAME_MAJOR "13" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-qt-doc.spec
+++ b/package/libyui-qt-doc.spec
@@ -17,11 +17,11 @@
 
 
 %define parent libyui-qt
-%define so_version 12
+%define so_version 13
 
 Name:           %{parent}-doc
 # DO NOT manually bump the version here; instead, use   rake version:bump
-Version:        2.53.0
+Version:        2.54.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui-qt.changes
+++ b/package/libyui-qt.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 11 13:52:19 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added MenuBar widget (bsc#1175115)
+- Bumped SO version to 13
+- 2.54.0
+
+-------------------------------------------------------------------
 Thu Jun  4 11:58:01 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added autoWrap to label widget (bsc#1172513)

--- a/package/libyui-qt.spec
+++ b/package/libyui-qt.spec
@@ -18,11 +18,11 @@
 
 Name:           libyui-qt
 # DO NOT manually bump the version here; instead, use   rake version:bump
-Version:        2.53.0
+Version:        2.54.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 12
+%define so_version 13
 %define bin_name %{name}%{so_version}
 
 BuildRequires:  boost-devel

--- a/src/QY2CharValidator.cc
+++ b/src/QY2CharValidator.cc
@@ -18,7 +18,7 @@
 
   File:	      QY2CharValidator.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   This is a pure Qt object - it can be used independently of YaST2.
 

--- a/src/QY2CharValidator.h
+++ b/src/QY2CharValidator.h
@@ -18,7 +18,7 @@
 
   File:	      QY2CharValidator.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   This is a pure Qt object - it can be used independently of YaST2.
 

--- a/src/QY2ComboTabWidget.cc
+++ b/src/QY2ComboTabWidget.cc
@@ -18,7 +18,7 @@
 
   File:	      QY2ComboTabWidget.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   This is a pure Qt widget - it can be used independently of YaST2.
 

--- a/src/QY2ComboTabWidget.h
+++ b/src/QY2ComboTabWidget.h
@@ -18,7 +18,7 @@
 
   File:	      QY2ComboTabWidget.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   This is a pure Qt widget - it can be used independently of YaST2.
 

--- a/src/QY2DiskUsageList.cc
+++ b/src/QY2DiskUsageList.cc
@@ -18,7 +18,7 @@
 
   File:	      QY2DiskUsageList.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   Textdomain "qt"
 

--- a/src/QY2DiskUsageList.h
+++ b/src/QY2DiskUsageList.h
@@ -18,7 +18,7 @@
 
   File:	      QY2DiskUsageList.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   This is a pure Qt widget - it can be used independently of YaST2.
 

--- a/src/QY2ListView.cc
+++ b/src/QY2ListView.cc
@@ -18,7 +18,7 @@
 
   File:	      QY2ListView.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   This is a pure Qt widget - it can be used independently of YaST2.
 

--- a/src/QY2ListView.h
+++ b/src/QY2ListView.h
@@ -18,7 +18,7 @@
 
   File:	      QY2ListView.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   This is a pure Qt widget - it can be used independently of YaST2.
 

--- a/src/YQAlignment.cc
+++ b/src/YQAlignment.cc
@@ -18,7 +18,7 @@
 
   File:	      YQAlignment.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQAlignment.h
+++ b/src/YQAlignment.h
@@ -18,7 +18,7 @@
 
   File:	      YQAlignment.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQApplication.cc
+++ b/src/YQApplication.cc
@@ -18,7 +18,7 @@
 
   File:		YQApplication.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
   Textdomain	"qt"
 /-*/

--- a/src/YQApplication.h
+++ b/src/YQApplication.h
@@ -18,7 +18,7 @@
 
   File:	      YQApplication.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQBarGraph.cc
+++ b/src/YQBarGraph.cc
@@ -18,7 +18,7 @@
 
   File:	      YQBarGraph.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQBarGraph.h
+++ b/src/YQBarGraph.h
@@ -18,7 +18,7 @@
 
   File:	      YQBarGraph.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQButtonBox.cc
+++ b/src/YQButtonBox.cc
@@ -18,7 +18,7 @@
 
   File:	      YQButtonBox.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQButtonBox.h
+++ b/src/YQButtonBox.h
@@ -18,7 +18,7 @@
 
   File:	      YQButtonBox.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQCheckBox.cc
+++ b/src/YQCheckBox.cc
@@ -18,7 +18,7 @@
 
   File:	      YQCheckBox.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQCheckBox.h
+++ b/src/YQCheckBox.h
@@ -18,7 +18,7 @@
 
   File:	      YQCheckBox.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQCheckBoxFrame.cc
+++ b/src/YQCheckBoxFrame.cc
@@ -18,7 +18,7 @@
 
   File:	      YQCheckBoxFrame.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQCheckBoxFrame.h
+++ b/src/YQCheckBoxFrame.h
@@ -18,7 +18,7 @@
 
   File:	      YQCheckBoxFrame.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQComboBox.cc
+++ b/src/YQComboBox.cc
@@ -18,7 +18,7 @@
 
   File:	      YQComboBox.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQComboBox.h
+++ b/src/YQComboBox.h
@@ -18,7 +18,7 @@
 
   File:	      YQComboBox.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQContextMenu.cc
+++ b/src/YQContextMenu.cc
@@ -169,7 +169,7 @@ YQContextMenu::menuEntryActivated( QAction* action )
 	 */
 
 	/*
-	 * the 100 delay is a ugly dirty workaround
+	 * The 100 delay is an ugly dirty workaround.
 	 */
 	_suppressCancelEvent = true;
 	QTimer::singleShot( 100, this, SLOT( returnNow() ) );

--- a/src/YQDateField.cc
+++ b/src/YQDateField.cc
@@ -18,7 +18,7 @@
 
   File:	      	YQDateField.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQDateField.h
+++ b/src/YQDateField.h
@@ -18,7 +18,7 @@
 
   File:	 	YQDateField.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQDialog.cc
+++ b/src/YQDialog.cc
@@ -18,7 +18,7 @@
 
   File:	      	YQDialog.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
   Textdomain	"qt"
 

--- a/src/YQDialog.h
+++ b/src/YQDialog.h
@@ -18,7 +18,7 @@
 
   File:	      YQDialog.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQDownloadProgress.cc
+++ b/src/YQDownloadProgress.cc
@@ -18,7 +18,7 @@
 
   File:	      YQLogView.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQDownloadProgress.h
+++ b/src/YQDownloadProgress.h
@@ -18,7 +18,7 @@
 
   File:	      YQDownloadProgress.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQDumbTab.cc
+++ b/src/YQDumbTab.cc
@@ -18,7 +18,7 @@
 
   File:	      YQDumbTab.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQDumbTab.h
+++ b/src/YQDumbTab.h
@@ -18,7 +18,7 @@
 
   File:	      YQDumbTab.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQEmpty.cc
+++ b/src/YQEmpty.cc
@@ -18,7 +18,7 @@
 
   File:	      YQEmpty.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQEmpty.h
+++ b/src/YQEmpty.h
@@ -18,7 +18,7 @@
 
   File:	      YQEmpty.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQFrame.cc
+++ b/src/YQFrame.cc
@@ -18,7 +18,7 @@
 
   File:	      YQFrame.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQFrame.h
+++ b/src/YQFrame.h
@@ -18,7 +18,7 @@
 
   File:	      YQFrame.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQGenericButton.cc
+++ b/src/YQGenericButton.cc
@@ -18,7 +18,7 @@
 
   File:	      YQGenericButton.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQGenericButton.h
+++ b/src/YQGenericButton.h
@@ -18,7 +18,7 @@
 
   File:	      YQGenericButton.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQImage.cc
+++ b/src/YQImage.cc
@@ -18,7 +18,7 @@
 
   File:	      YQImage.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQImage.h
+++ b/src/YQImage.h
@@ -18,7 +18,7 @@
 
   File:	      YQImage.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQInputField.cc
+++ b/src/YQInputField.cc
@@ -18,7 +18,7 @@
 
   File:	      YQInputField.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
   Textdomain "qt"
 

--- a/src/YQInputField.h
+++ b/src/YQInputField.h
@@ -18,7 +18,7 @@
 
   File:	      YQInputField.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQIntField.cc
+++ b/src/YQIntField.cc
@@ -18,7 +18,7 @@
 
   File:	      YQIntField.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQIntField.h
+++ b/src/YQIntField.h
@@ -18,7 +18,7 @@
 
   File:	      YQIntField.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQLabel.cc
+++ b/src/YQLabel.cc
@@ -18,7 +18,7 @@
 
   File:	      YQLabel.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQLabel.h
+++ b/src/YQLabel.h
@@ -18,7 +18,7 @@
 
   File:	      YQLabel.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQLayoutBox.cc
+++ b/src/YQLayoutBox.cc
@@ -18,7 +18,7 @@
 
   File:	      YQLayoutBox.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQLayoutBox.h
+++ b/src/YQLayoutBox.h
@@ -18,7 +18,7 @@
 
   File:	      YQLayoutBox.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQLogView.cc
+++ b/src/YQLogView.cc
@@ -18,7 +18,7 @@
 
   File:	      YQLogView.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQLogView.h
+++ b/src/YQLogView.h
@@ -18,7 +18,7 @@
 
   File:	      YQLogView.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMainWinDock.cc
+++ b/src/YQMainWinDock.cc
@@ -18,7 +18,7 @@
 
   File:	      YQMainWinDock.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMainWinDock.h
+++ b/src/YQMainWinDock.h
@@ -18,7 +18,7 @@
 
   File:	      YQMainWinDock.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMenuBar.cc
+++ b/src/YQMenuBar.cc
@@ -1,0 +1,213 @@
+/*
+  Copyright (C) 2020 SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+  File:	      YQMenuBar.cc
+
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
+
+/-*/
+
+
+#include <QMenu>
+#include <QTimer>
+#define YUILogComponent "qt-ui"
+#include <yui/YUILog.h>
+
+#include "utf8.h"
+#include "YQUI.h"
+#include "YQMenuBar.h"
+#include "YQSignalBlocker.h"
+#include <yui/YEvent.h>
+
+using std::string;
+
+
+
+YQMenuBar::YQMenuBar( YWidget * parent )
+    : QMenuBar( (QWidget *) parent->widgetRep() )
+    , YMenuBar( parent )
+    , _selectedItem( 0 )
+{
+    setWidgetRep( this );
+}
+
+
+YQMenuBar::~YQMenuBar()
+{
+    // NOP
+}
+
+
+void
+YQMenuBar::rebuildMenuTree()
+{
+    //
+    // Delete any previous menus
+    // (in case the menu items got replaced)
+    //
+
+    QMenuBar::clear();
+    _actionMap.clear();
+    _selectedItem = 0;
+
+
+    //
+    // Create toplevel menus
+    //
+
+    for ( YItemIterator it = itemsBegin(); it != itemsEnd(); ++it )
+    {
+	YItem * item = *it;
+
+        if ( ! item->hasChildren() )
+            YUI_THROW( YUIException( "YQMenuBar: Only menus allowed on toplevel." ) );
+
+        QMenu * menu = addMenu( fromUTF8( item->label() ));
+        YUI_CHECK_NEW( menu );
+
+        connect( menu, &pclass(menu)::triggered,
+                 this, &pclass(this)::menuEntryActivated );
+
+        // Recursively add menu content
+        rebuildMenuTree( menu, item->childrenBegin(), item->childrenEnd() );
+    }
+}
+
+
+void
+YQMenuBar::rebuildMenuTree( QMenu * parentMenu, YItemIterator begin, YItemIterator end )
+{
+    for ( YItemIterator it = begin; it != end; ++it )
+    {
+	YItem * item = *it;
+	QIcon   icon;
+
+	if ( item->hasIconName() )
+	    icon = YQUI::ui()->loadIcon( item->iconName() );
+
+	if ( item->hasChildren() )
+	{
+	    QMenu * subMenu = parentMenu->addMenu( fromUTF8( item->label() ));
+
+	    if ( ! icon.isNull() )
+		subMenu->setIcon( icon );
+
+	    connect( subMenu,	&pclass(subMenu)::triggered,
+		     this,	&pclass(this)::menuEntryActivated );
+
+	    rebuildMenuTree( subMenu, item->childrenBegin(), item->childrenEnd() );
+	}
+	else // No children - leaf entry
+	{
+	    // item->index() is guaranteed to be unique within this YMenuBar's items,
+	    // so it can easily be used as unique ID in all Q3PopupMenus that belong
+	    // to this YQMenuBar.
+
+            QAction * action = parentMenu->addAction( fromUTF8( item->label() ) );
+            _actionMap[ action ] = item;
+
+            if ( ! icon.isNull() )
+                action->setIcon( icon );
+	}
+    }
+}
+
+
+void
+YQMenuBar::menuEntryActivated( QAction * action )
+{
+    if ( _actionMap.contains( action ) )
+         _selectedItem = _actionMap[ action ];
+
+    if ( _selectedItem )
+    {
+        yuiDebug() << "Selected menu entry \"" << fromUTF8( _selectedItem->label() ) << "\"" << endl;
+
+	/*
+	 * Defer the real returnNow() until all popup related events have been
+	 * processed. This took me some hours to figure out; obviously
+	 * exit_loop() doesn't have any effect as long as there are still
+	 * popups open. So be it - use a zero timer to perform the real
+	 * returnNow() later.
+	 */
+
+	/*
+	 * the 100 delay is a ugly dirty workaround
+	 */
+	QTimer::singleShot( 100, this, SLOT( returnNow() ) );
+    }
+    else
+    {
+	yuiError() << "Unknown action \"" << action->text() << "\"" << endl;
+    }
+}
+
+
+void
+YQMenuBar::returnNow()
+{
+    if ( _selectedItem )
+    {
+	YQUI::ui()->sendEvent( new YMenuEvent( _selectedItem ) );
+	_selectedItem = 0;
+    }
+}
+
+
+
+void
+YQMenuBar::setEnabled( bool enabled )
+{
+    YWidget::setEnabled( enabled );
+}
+
+
+int YQMenuBar::preferredWidth()
+{
+    return sizeHint().width();
+}
+
+
+int YQMenuBar::preferredHeight()
+{
+    return sizeHint().height();
+}
+
+
+void
+YQMenuBar::setSize( int newWidth, int newHeight )
+{
+    QWidget::resize( newWidth, newHeight );
+}
+
+
+bool
+YQMenuBar::setKeyboardFocus()
+{
+    QWidget::setFocus();
+
+    return true;
+}
+
+
+void
+YQMenuBar::activateItem( YMenuItem * item )
+{
+    if ( item )
+        YQUI::ui()->sendEvent( new YMenuEvent( item ) );
+}

--- a/src/YQMenuBar.cc
+++ b/src/YQMenuBar.cc
@@ -151,7 +151,7 @@ YQMenuBar::menuEntryActivated( QAction * action )
 	 */
 
 	/*
-	 * The 100 delay is a ugly dirty workaround.
+	 * The 100 delay is an ugly dirty workaround.
 	 */
 	QTimer::singleShot( 100, this, SLOT( returnNow() ) );
     }

--- a/src/YQMenuBar.cc
+++ b/src/YQMenuBar.cc
@@ -79,7 +79,7 @@ YQMenuBar::rebuildMenuTree()
             YUI_THROW( YUIException( "YQMenuBar: Only menus allowed on toplevel." ) );
 
         QMenu * menu = QMenuBar::addMenu( fromUTF8( item->label() ));
-        YUI_CHECK_NEW( menu );
+        item->setUiItem( menu );
 
         connect( menu, &pclass(menu)::triggered,
                  this, &pclass(this)::menuEntryActivated );
@@ -109,10 +109,11 @@ YQMenuBar::rebuildMenuTree( QMenu * parentMenu, YItemIterator begin, YItemIterat
 	else if ( item->isMenu() )
 	{
 	    QMenu * subMenu = parentMenu->addMenu( fromUTF8( item->label() ));
+            item->setUiItem( subMenu );
 
 	    if ( ! icon.isNull() )
 		subMenu->setIcon( icon );
-
+            
 	    connect( subMenu,	&pclass(subMenu)::triggered,
 		     this,	&pclass(this)::menuEntryActivated );
 
@@ -121,6 +122,7 @@ YQMenuBar::rebuildMenuTree( QMenu * parentMenu, YItemIterator begin, YItemIterat
 	else // Plain menu item (leaf item)
 	{
             QAction * action = parentMenu->addAction( fromUTF8( item->label() ) );
+            item->setUiItem( action );
             _actionMap[ action ] = item;
 
             if ( ! icon.isNull() )
@@ -170,6 +172,29 @@ YQMenuBar::returnNow()
     }
 }
 
+
+void
+YQMenuBar::setItemEnabled( YMenuItem * item, bool enabled )
+{
+    QObject * qObj = static_cast<QObject *>( item->uiItem() );
+
+    if ( qObj )
+    {
+        QMenu * menu = qobject_cast<QMenu *>( qObj );
+
+        if ( menu )
+            menu->setEnabled( enabled );
+        else
+        {
+            QAction * action = qobject_cast<QAction *>( qObj );
+
+            if ( action )
+                action->setEnabled( enabled );
+        }
+    }
+
+    YMenuWidget::setItemEnabled( item, enabled );
+}
 
 
 void

--- a/src/YQMenuBar.h
+++ b/src/YQMenuBar.h
@@ -1,0 +1,134 @@
+/*
+  Copyright (C) 2020 SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+  File:	      YQMenuBar.h
+
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
+
+/-*/
+
+
+#ifndef YQMenuBar_h
+#define YQMenuBar_h
+
+#include <QMenuBar>
+#include <yui/YMenuBar.h>
+#include <QHash>
+
+class QAction;
+class QPushButton;
+class QMenu;
+
+class YQMenuBar : public QMenuBar, public YMenuBar
+{
+    Q_OBJECT
+
+public:
+    /**
+     * Constructor.
+     **/
+    YQMenuBar( YWidget * parent );
+
+    /**
+     * Destructor.
+     **/
+    virtual ~YQMenuBar();
+
+    /**
+     * Rebuild the displayed menu tree from the internally stored YMenuItems.
+     *
+     * Implemented from YMenuBar.
+     **/
+    virtual void rebuildMenuTree();
+
+    /**
+     * Set enabled / disabled state.
+     *
+     * Reimplemented from YWidget.
+     **/
+    virtual void setEnabled( bool enabled );
+
+    /**
+     * Preferred width of the widget.
+     *
+     * Reimplemented from YWidget.
+     **/
+    virtual int preferredWidth();
+
+    /**
+     * Preferred height of the widget.
+     *
+     * Reimplemented from YWidget.
+     **/
+    virtual int preferredHeight();
+
+    /**
+     * Set the new size of the widget.
+     *
+     * Reimplemented from YWidget.
+     **/
+    virtual void setSize( int newWidth, int newHeight );
+
+    /**
+     * Accept the keyboard focus.
+     **/
+    virtual bool setKeyboardFocus();
+
+    /**
+    * Activate the item selected in the tree. Can be used in tests to simulate
+    * user input.
+    *
+    * Derived classes are required to implement this.
+    **/
+    virtual void activateItem( YMenuItem * item );
+
+
+protected slots:
+
+    /**
+     * Triggered when any menu item is activated.
+     **/
+    void menuEntryActivated( QAction * menuItem );
+
+    /**
+     * Triggered via menuEntryActivated() by zero timer to get back in sync
+     * with the Qt event loop.
+     **/
+    void returnNow();
+
+
+protected:
+
+    /**
+     * Recursively insert menu items into 'menu' from iterator 'begin' to
+     * iterator 'end'.
+     **/
+    void rebuildMenuTree( QMenu * menu,
+                          YItemIterator begin,
+                          YItemIterator end );
+
+
+    //
+    // Data members
+    //
+
+    YItem *                 _selectedItem;
+    QMap<QAction *,YItem *> _actionMap;
+};
+
+#endif // YQMenuBar_h

--- a/src/YQMenuBar.h
+++ b/src/YQMenuBar.h
@@ -127,8 +127,8 @@ protected:
     // Data members
     //
 
-    YItem *                 _selectedItem;
-    QMap<QAction *,YItem *> _actionMap;
+    YMenuItem *                 _selectedItem;
+    QMap<QAction *,YMenuItem *> _actionMap;
 };
 
 #endif // YQMenuBar_h

--- a/src/YQMenuBar.h
+++ b/src/YQMenuBar.h
@@ -90,11 +90,16 @@ public:
     virtual bool setKeyboardFocus();
 
     /**
-    * Activate the item selected in the tree. Can be used in tests to simulate
-    * user input.
-    *
-    * Derived classes are required to implement this.
-    **/
+     * Enable or disable an item.
+     *
+     * Reimplemented from YMenuWidget.
+     **/
+    virtual void setItemEnabled( YMenuItem * item, bool enabled );
+
+    /**
+     * Activate the item selected in the tree. Can be used in tests to simulate
+     * user input.
+     **/
     virtual void activateItem( YMenuItem * item );
 
 

--- a/src/YQMenuButton.cc
+++ b/src/YQMenuButton.cc
@@ -169,7 +169,7 @@ YQMenuButton::menuEntryActivated( QAction * action )
 	 */
 
 	/*
-	 * The 100 delay is a ugly dirty workaround.
+	 * The 100 delay is an ugly dirty workaround.
 	 */
 	QTimer::singleShot( 100, this, SLOT( returnNow() ) );
     }

--- a/src/YQMenuButton.cc
+++ b/src/YQMenuButton.cc
@@ -1,5 +1,6 @@
 /*
   Copyright (C) 2000-2012 Novell, Inc
+  Copyright (C) 2020 SUSE LLC
   This library is free software; you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as
   published by the Free Software Foundation; either version 2.1 of the
@@ -23,10 +24,11 @@
 /-*/
 
 
-#include <qpushbutton.h>
+#include <QPushButton>
 #include <QMenu>
-#include <qsize.h>
-#include <qtimer.h>
+#include <QSize>
+#include <QTimer>
+
 #define YUILogComponent "qt-ui"
 #include <yui/YUILog.h>
 
@@ -121,6 +123,7 @@ YQMenuButton::rebuildMenuTree( QMenu * parentMenu, YItemIterator begin, YItemIte
 	else if ( item->isMenu() )
 	{
 	    QMenu * subMenu = parentMenu->addMenu( fromUTF8( item->label() ));
+            item->setUiItem( subMenu );
 
 	    if ( ! icon.isNull() )
 		subMenu->setIcon( icon );
@@ -137,6 +140,7 @@ YQMenuButton::rebuildMenuTree( QMenu * parentMenu, YItemIterator begin, YItemIte
 	    // to this YQMenuButton.
 
             QAction * action = parentMenu->addAction( fromUTF8( item->label() ) );
+            item->setUiItem( action );
             _actionMap[ action ] = item;
 
             if ( ! icon.isNull() )
@@ -184,6 +188,30 @@ YQMenuButton::returnNow()
 	YQUI::ui()->sendEvent( new YMenuEvent( _selectedItem ) );
 	_selectedItem = 0;
     }
+}
+
+
+void
+YQMenuButton::setItemEnabled( YMenuItem * item, bool enabled )
+{
+    QObject * qObj = static_cast<QObject *>( item->uiItem() );
+
+    if ( qObj )
+    {
+        QMenu * menu = qobject_cast<QMenu *>( qObj );
+
+        if ( menu )
+            menu->setEnabled( enabled );
+        else
+        {
+            QAction * action = qobject_cast<QAction *>( qObj );
+
+            if ( action )
+                action->setEnabled( enabled );
+        }
+    }
+
+    YMenuWidget::setItemEnabled( item, enabled );
 }
 
 

--- a/src/YQMenuButton.cc
+++ b/src/YQMenuButton.cc
@@ -18,7 +18,7 @@
 
   File:	      YQMenuButton.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMenuButton.h
+++ b/src/YQMenuButton.h
@@ -18,7 +18,7 @@
 
   File:	      YQMenuButton.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMenuButton.h
+++ b/src/YQMenuButton.h
@@ -28,7 +28,7 @@
 
 #include <qwidget.h>
 #include <yui/YMenuButton.h>
-#include <QHash>
+#include <QMap>
 
 class QAction;
 class QPushButton;
@@ -130,9 +130,9 @@ protected:
     // Data members
     //
 
-    YMenuItem *		_selectedItem;
-    QPushButton * 	_qt_button;
-    QHash<QAction*,int> _serials;
+    QPushButton * 	        _qt_button;
+    YMenuItem *		        _selectedItem;
+    QMap<QAction *,YMenuItem *> _actionMap;
 };
 
 #endif // YQMenuButton_h

--- a/src/YQMenuButton.h
+++ b/src/YQMenuButton.h
@@ -98,11 +98,17 @@ public:
     virtual bool setKeyboardFocus();
 
     /**
-    * Activate the item selected in the tree. Can be used in tests to simulate user input.
-    *
-    * Derived classes are required to implement this.
-    **/
+     * Enable or disable an item.
+     *
+     * Reimplemented from YMenuWidget.
+     **/
+    virtual void setItemEnabled( YMenuItem * item, bool enabled );
+
+    /**
+     * Activate the item selected in the tree. Can be used in tests to simulate user input.
+     **/
     virtual void activateItem( YMenuItem * item );
+
 
 protected slots:
 

--- a/src/YQMultiLineEdit.cc
+++ b/src/YQMultiLineEdit.cc
@@ -18,7 +18,7 @@
 
   File:	      YQMultiLineEdit.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMultiLineEdit.h
+++ b/src/YQMultiLineEdit.h
@@ -18,7 +18,7 @@
 
   File:	      YQMultiLineEdit.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMultiProgressMeter.cc
+++ b/src/YQMultiProgressMeter.cc
@@ -18,7 +18,7 @@
 
   File:	      YQMultiProgressMeter.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMultiProgressMeter.h
+++ b/src/YQMultiProgressMeter.h
@@ -18,7 +18,7 @@
 
   File:	      YQMultiProgressMeter.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMultiSelectionBox.cc
+++ b/src/YQMultiSelectionBox.cc
@@ -18,7 +18,7 @@
 
   File:	      YQMultiSelectionBox.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQMultiSelectionBox.h
+++ b/src/YQMultiSelectionBox.h
@@ -18,7 +18,7 @@
 
   File:	      YQMultiSelectionBox.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQOptionalWidgetFactory.cc
+++ b/src/YQOptionalWidgetFactory.cc
@@ -18,7 +18,7 @@
 
   File:		YQOptionalWidgetFactory.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQOptionalWidgetFactory.h
+++ b/src/YQOptionalWidgetFactory.h
@@ -18,7 +18,7 @@
 
   File:		YQOptionalWidgetFactory.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQPartitionSplitter.cc
+++ b/src/YQPartitionSplitter.cc
@@ -18,7 +18,7 @@
 
   File:	      YQPartitionSplitter.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQPartitionSplitter.h
+++ b/src/YQPartitionSplitter.h
@@ -18,7 +18,7 @@
 
   File:	      YQPartitionSplitter.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQProgressBar.cc
+++ b/src/YQProgressBar.cc
@@ -18,7 +18,7 @@
 
   File:	      YQProgressBar.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQProgressBar.h
+++ b/src/YQProgressBar.h
@@ -18,7 +18,7 @@
 
   File:	      YQProgressBar.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQPushButton.cc
+++ b/src/YQPushButton.cc
@@ -18,7 +18,7 @@
 
   File:	      YQPushButton.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQPushButton.h
+++ b/src/YQPushButton.h
@@ -18,7 +18,7 @@
 
   File:	      YQPushButton.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQRadioButton.cc
+++ b/src/YQRadioButton.cc
@@ -18,7 +18,7 @@
 
   File:	      YQRadioButton.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQRadioButton.h
+++ b/src/YQRadioButton.h
@@ -18,7 +18,7 @@
 
   File:	      YQRadioButton.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQRadioButtonGroup.cc
+++ b/src/YQRadioButtonGroup.cc
@@ -18,7 +18,7 @@
 
   File:	      YQRadioButtonGroup.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQRadioButtonGroup.h
+++ b/src/YQRadioButtonGroup.h
@@ -18,7 +18,7 @@
 
   File:	      YQRadioButtonGroup.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQReplacePoint.cc
+++ b/src/YQReplacePoint.cc
@@ -18,7 +18,7 @@
 
   File:	      YQReplacePoint.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQReplacePoint.h
+++ b/src/YQReplacePoint.h
@@ -18,7 +18,7 @@
 
   File:	      YQReplacePoint.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQRichText.cc
+++ b/src/YQRichText.cc
@@ -19,7 +19,7 @@
 
   File:	      YQRichText.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQRichText.h
+++ b/src/YQRichText.h
@@ -19,7 +19,7 @@
 
   File:	      YQRichText.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSelectionBox.cc
+++ b/src/YQSelectionBox.cc
@@ -18,7 +18,7 @@
 
   File:	      YQSelectionBox.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSelectionBox.h
+++ b/src/YQSelectionBox.h
@@ -18,7 +18,7 @@
 
   File:	      YQSelectionBox.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSignalBlocker.cc
+++ b/src/YQSignalBlocker.cc
@@ -18,7 +18,7 @@
 
   File:	      YQSignalBlocker.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSignalBlocker.h
+++ b/src/YQSignalBlocker.h
@@ -18,7 +18,7 @@
 
   File:	      YQSignalBlocker.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSlider.cc
+++ b/src/YQSlider.cc
@@ -18,7 +18,7 @@
 
   File:	      YQSlider.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSlider.h
+++ b/src/YQSlider.h
@@ -18,7 +18,7 @@
 
   File:	      YQSlider.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSpacing.cc
+++ b/src/YQSpacing.cc
@@ -18,7 +18,7 @@
 
   File:	      YQSpacing.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSpacing.h
+++ b/src/YQSpacing.h
@@ -18,7 +18,7 @@
 
   File:	      YQSpacing.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSquash.cc
+++ b/src/YQSquash.cc
@@ -18,7 +18,7 @@
 
   File:	      YQSquash.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQSquash.h
+++ b/src/YQSquash.h
@@ -18,7 +18,7 @@
 
   File:	      YQSquash.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQTable.cc
+++ b/src/YQTable.cc
@@ -18,7 +18,7 @@
 
   File:	      YQTable.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQTable.h
+++ b/src/YQTable.h
@@ -18,7 +18,7 @@
 
   File:	      YQTable.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQTimeField.cc
+++ b/src/YQTimeField.cc
@@ -18,7 +18,7 @@
 
   File:		YQTimeField.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQTimeField.h
+++ b/src/YQTimeField.h
@@ -18,7 +18,7 @@
 
   File:		YQTimeField.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQTimezoneSelector.h
+++ b/src/YQTimezoneSelector.h
@@ -18,7 +18,7 @@
 
   File:		YQTimezoneSelector.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQTree.cc
+++ b/src/YQTree.cc
@@ -18,7 +18,7 @@
 
   File:	      YQTree.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQTree.h
+++ b/src/YQTree.h
@@ -18,7 +18,7 @@
 
   File:       YQTree.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQUI.cc
+++ b/src/YQUI.cc
@@ -18,7 +18,7 @@
 
   File:		YQUI.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
   Textdomain	"qt"
 

--- a/src/YQUI.h
+++ b/src/YQUI.h
@@ -18,7 +18,7 @@
 
   File:		YQUI.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQUI_builtins.cc
+++ b/src/YQUI_builtins.cc
@@ -18,7 +18,7 @@
 
   File:         YUIQt_builtins.cc
 
-  Author:       Stefan Hundhammer <sh@suse.de>
+  Author:       Stefan Hundhammer <shundhammer@suse.de>
 
   Textdomain    "qt"
 

--- a/src/YQWidgetCaption.cc
+++ b/src/YQWidgetCaption.cc
@@ -18,7 +18,7 @@
 
   File:	      YQWidgetCaption.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQWidgetCaption.h
+++ b/src/YQWidgetCaption.h
@@ -18,7 +18,7 @@
 
   File:	      YQWidgetCaption.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQWidgetFactory.cc
+++ b/src/YQWidgetFactory.cc
@@ -251,6 +251,16 @@ YQWidgetFactory::createMenuButton( YWidget * parent, const string & label )
 }
 
 
+YQMenuBar *
+YQWidgetFactory::createMenuBar( YWidget * parent )
+{
+    YQMenuBar * menuBar = new YQMenuBar( parent );
+    YUI_CHECK_NEW( menuBar );
+
+    return menuBar;
+}
+
+
 YQMultiLineEdit *
 YQWidgetFactory::createMultiLineEdit( YWidget * parent, const string & label )
 {

--- a/src/YQWidgetFactory.cc
+++ b/src/YQWidgetFactory.cc
@@ -18,7 +18,7 @@
 
   File:         YQWidgetFactory.cc
 
-  Author:       Stefan Hundhammer <sh@suse.de>
+  Author:       Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQWidgetFactory.h
+++ b/src/YQWidgetFactory.h
@@ -44,6 +44,7 @@
 #include "YQLabel.h"
 #include "YQLayoutBox.h"
 #include "YQLogView.h"
+#include "YQMenuBar.h"
 #include "YQMenuButton.h"
 #include "YQMultiLineEdit.h"
 #include "YQMultiSelectionBox.h"
@@ -148,6 +149,7 @@ public:
 
     virtual YQItemSelector *             createItemSelector             ( YWidget * parent, bool enforceSingleSelection = true );
     virtual YQCustomStatusItemSelector * createCustomStatusItemSelector ( YWidget * parent, const YItemCustomStatusVector & customStates );
+    virtual YQMenuBar *                  createMenuBar                  ( YWidget * parent );
 
 
 protected:

--- a/src/YQWidgetFactory.h
+++ b/src/YQWidgetFactory.h
@@ -18,7 +18,7 @@
 
   File:		YQWidgetFactory.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQWizard.cc
+++ b/src/YQWizard.cc
@@ -18,7 +18,7 @@
 
   File:		YQWizard.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
   Textdomain	"qt"
 

--- a/src/YQWizard.h
+++ b/src/YQWizard.h
@@ -18,7 +18,7 @@
 
   File:	      YQWizard.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQWizardButton.cc
+++ b/src/YQWizardButton.cc
@@ -18,7 +18,7 @@
 
   File:	      YQWizardButton.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQWizardButton.h
+++ b/src/YQWizardButton.h
@@ -18,7 +18,7 @@
 
   File:	      YQWizardButton.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YQi18n.h
+++ b/src/YQi18n.h
@@ -18,7 +18,7 @@
 
   File:		YQi18n.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -18,7 +18,7 @@
 
   File:	      utf8.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 


### PR DESCRIPTION
## Trello

https://trello.com/c/4GtDpmMo/

## Overview

This adds a MenuBar widget to the Qt UI.

For more details, see the main PR for this feature:

https://github.com/libyui/libyui/pull/169

## Travis Build Failure

This doesn't build because the image used by Travis does not yet contain the libyui with the new features. This is expected.

## Related PRs

- libyui: https://github.com/libyui/libyui/pull/169
- NCurses UI: https://github.com/libyui/libyui-ncurses/pull/93
- UI Interpreter: https://github.com/yast/yast-ycp-ui-bindings/pull/53