### PR TITLE
Refresh widgets after shortcuts changes

### DIFF
--- a/src/YQItemSelector.cc
+++ b/src/YQItemSelector.cc
@@ -298,6 +298,20 @@ void YQItemSelector::activateItem( YItem * item )
         YQUI::ui()->sendEvent( new YWidgetEvent( this, YEvent::ValueChanged ) );
 }
 
+
+void YQItemSelector::shortcutChanged()
+{
+    // Any of the items might have its keyboard shortcut changed, but we don't
+    // know which one. So let's simply set all item labels again.
+
+    for ( YItemConstIterator it = itemsBegin(); it != itemsEnd(); ++it )
+    {
+	YItem * item = *it;
+	_itemWidgets[item]->setLabel( fromUTF8( item->label() ) );
+    }
+}
+
+
 //-----------------------------------------------------------------------------
 
 
@@ -501,4 +515,10 @@ void YQSelectorItemWidget::setSelected( bool sel )
 void YQSelectorItemWidget::slotSelectionChanged( bool selected )
 {
     emit selectionChanged( this, selected );
+}
+
+
+void YQSelectorItemWidget::setLabel( const QString & label )
+{
+    _headingToggle->setText( label );
 }

--- a/src/YQItemSelector.h
+++ b/src/YQItemSelector.h
@@ -152,6 +152,13 @@ public:
      **/
     virtual void activateItem( YItem * item );
 
+    /**
+     * Notification that some shortcut was changed.
+     *
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void shortcutChanged();
+
 protected slots:
 
     /**
@@ -243,6 +250,13 @@ public:
      * Return 'true' if the parent YItemSelector has multi selection (n-of-m).
      **/
     bool multiSelection() const { return ! singleSelection(); }
+
+    /**
+     * Set a new label.
+     *
+     * This method is mainly used when fixing shortcuts conflicts.
+     **/
+    void setLabel( const QString & label );
 
     /**
      * Return the widget that handles the selection: Either a QRadioButton or a

--- a/src/YQMenuBar.cc
+++ b/src/YQMenuBar.cc
@@ -113,7 +113,7 @@ YQMenuBar::rebuildMenuTree( QMenu * parentMenu, YItemIterator begin, YItemIterat
 
 	    if ( ! icon.isNull() )
 		subMenu->setIcon( icon );
-            
+
 	    connect( subMenu,	&pclass(subMenu)::triggered,
 		     this,	&pclass(this)::menuEntryActivated );
 
@@ -237,4 +237,14 @@ YQMenuBar::activateItem( YMenuItem * item )
 {
     if ( item )
         YQUI::ui()->sendEvent( new YMenuEvent( item ) );
+}
+
+
+void
+YQMenuBar::shortcutChanged()
+{
+    // Any of the items might have its keyboard shortcut changed, but we don't
+    // know which one. So let's simply rebuild the menu bar again.
+
+    rebuildMenuTree();
 }

--- a/src/YQMenuBar.cc
+++ b/src/YQMenuBar.cc
@@ -246,5 +246,8 @@ YQMenuBar::shortcutChanged()
     // Any of the items might have its keyboard shortcut changed, but we don't
     // know which one. So let's simply rebuild the menu bar again.
 
+    // FIXME: This is called every time a menu shortcut is changed. Rebuilding the menu tree is an
+    // expensive operation. Try to avoid multiple rebuilds by calling this only after fixing all the
+    // shortcuts.
     rebuildMenuTree();
 }

--- a/src/YQMenuBar.h
+++ b/src/YQMenuBar.h
@@ -102,6 +102,12 @@ public:
      **/
     virtual void activateItem( YMenuItem * item );
 
+    /**
+     * Notification that some shortcut was changed.
+     *
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void shortcutChanged();
 
 protected slots:
 


### PR DESCRIPTION
Improvements to avoid conflicts with the shortcuts of the *YQItemSelector* and *YQMenuBar* widgets,  see https://github.com/libyui/libyui/pull/170.

* PBI: https://trello.com/c/fCUBIGGg/2023-3-tw-p3-1175142-yast-menu-bar-toplevel-shortcut-conflicts
* https://bugzilla.suse.com/show_bug.cgi?id=1175142

Note: The changes in this PR imply to bump the so version, but this will be done when the *sprint-108* branch includes all the changes to do during this sprint.