### PR TITLE
Nested Items in Table Widgets

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,11 +1,11 @@
 SET(VERSION_MAJOR "2")
-SET(VERSION_MINOR "54")
+SET(VERSION_MINOR "55")
 SET(VERSION_PATCH "0")
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is needed for the libyui-qt core ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
-SET( SONAME_MAJOR "13" )
+SET( SONAME_MAJOR "14" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-qt-doc.spec
+++ b/package/libyui-qt-doc.spec
@@ -17,11 +17,11 @@
 
 
 %define parent libyui-qt
-%define so_version 13
+%define so_version 14
 
 Name:           %{parent}-doc
 # DO NOT manually bump the version here; instead, use   rake version:bump
-Version:        2.54.0
+Version:        2.55.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui-qt.changes
+++ b/package/libyui-qt.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Fri Oct  9 07:41:44 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Resolve hotkeys conflicts for widgets with multiple hotkeys
+  (related to bsc#1175489).
+- Allow to show/hide menus and menu items (related to
+  manatools/libyui-mga#1).
+- Allow nested items in tables (bsc#1176402).
+- Bumped SO version to 14.
+- 2.55.0
+
+-------------------------------------------------------------------
 Tue Aug 11 13:52:19 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added MenuBar widget (bsc#1175115)

--- a/package/libyui-qt.spec
+++ b/package/libyui-qt.spec
@@ -18,11 +18,11 @@
 
 Name:           libyui-qt
 # DO NOT manually bump the version here; instead, use   rake version:bump
-Version:        2.54.0
+Version:        2.55.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 13
+%define so_version 14
 %define bin_name %{name}%{so_version}
 
 BuildRequires:  boost-devel

--- a/src/QY2DiskUsageList.h
+++ b/src/QY2DiskUsageList.h
@@ -30,7 +30,7 @@
 
 #include <QY2ListView.h>
 #include <yui/FSize.h>
-#include <qcolor.h>
+#include <QColor>
 
 
 class QY2DiskUsageListItem;

--- a/src/QY2Styler.cc
+++ b/src/QY2Styler.cc
@@ -58,7 +58,7 @@ QY2Styler::QY2Styler( QObject * parent,
     : QObject( parent )
 {
     QPixmapCache::setCacheLimit( 5 * 1024 );
-    yuiDebug() << "Styler created" << endl;
+    // yuiDebug() << "Styler created" << endl;
 
     setDefaultStyleSheet(defaultStyleSheet);
     setAlternateStyleSheet(alternateStyleSheet);
@@ -73,7 +73,7 @@ QY2Styler::styler()
 
     if ( ! styler )
     {
-        yuiDebug() << "Creating QY2Styler singleton" << endl;
+        // yuiDebug() << "Creating QY2Styler singleton" << endl;
 
         QString y2style = getenv("Y2STYLE");
         QString y2altstyle = getenv("Y2ALTSTYLE");

--- a/src/YQMenuBar.cc
+++ b/src/YQMenuBar.cc
@@ -246,8 +246,9 @@ YQMenuBar::shortcutChanged()
     // Any of the items might have its keyboard shortcut changed, but we don't
     // know which one. So let's simply rebuild the menu bar again.
 
-    // FIXME: This is called every time a menu shortcut is changed. Rebuilding the menu tree is an
-    // expensive operation. Try to avoid multiple rebuilds by calling this only after fixing all the
-    // shortcuts.
+    // FIXME: This is called every time a menu shortcut is changed. Rebuilding
+    // the menu tree is an expensive operation. Try to avoid multiple rebuilds
+    // by calling this only after fixing all the shortcuts.
+
     rebuildMenuTree();
 }

--- a/src/YQTable.cc
+++ b/src/YQTable.cc
@@ -535,7 +535,7 @@ YQTableListViewItem::smartSortKey(int column) const
 {
     const YTableCell* tableCell = origItem()->cell(column);
 
-    if (tableCell->hasSortKey())
+    if (tableCell && tableCell->hasSortKey())
         return QString::fromUtf8(tableCell->sortKey().c_str());
     else
         return text(column).trimmed();

--- a/src/YQTable.h
+++ b/src/YQTable.h
@@ -185,12 +185,6 @@ protected:
     void addItem( YItem * item, bool batchMode, bool resizeColumnsToContent );
 
     /**
-     * Set the alignment of each column of a Qt item clone according to the
-     * table's alignments.
-     **/
-    void setColumnsAlignment( YQTableListViewItem * clone );
-
-    /**
      * Clone (create Qt item counterparts) for all child items of 'parentItem'.
      * Set their Qt item parent to 'parentItemClone'.
      **/
@@ -253,6 +247,18 @@ public:
     virtual QString smartSortKey(int column) const override;
 
 protected:
+
+    /**
+     * Common initializations for all constructors
+     **/
+    void init();
+
+    /**
+     * Set the alignment for each column according to the YTable parent's
+     * alignment.
+     **/
+    void setColAlignment();
+
 
     YQTable *	 _table;
     YTableItem * _origItem;

--- a/src/YQTable.h
+++ b/src/YQTable.h
@@ -32,7 +32,8 @@
 
 class QY2ListView;
 class QTreeWidgetItem;
-class YQListViewItem;
+class YQTableListViewItem;
+
 
 class YQTable : public QFrame, public YTable
 {
@@ -161,9 +162,9 @@ protected slots:
     void slotActivated( QTreeWidgetItem * );
 
     /**
-     * Propagate a context menu selection
+     * Propagate a context menu selection.
      *
-     * This will trigger an 'ContextMenuActivated' event if 'notifyContextMenu' is set.
+     * This will trigger a 'ContextMenuActivated' event if 'notifyContextMenu' is set.
      **/
     void slotContextMenu ( const QPoint & pos );
 
@@ -183,6 +184,19 @@ protected:
      **/
     void addItem( YItem * item, bool batchMode, bool resizeColumnsToContent );
 
+    /**
+     * Set the alignment of each column of a Qt item clone according to the
+     * table's alignments.
+     **/
+    void setColumnsAlignment( YQTableListViewItem * clone );
+
+    /**
+     * Clone (create Qt item counterparts) for all child items of 'parentItem'.
+     * Set their Qt item parent to 'parentItemClone'.
+     **/
+    void cloneChildItems( YTableItem          * parentItem,
+                          YQTableListViewItem * parentItemClone );
+
     //
     // Data members
     //
@@ -200,11 +214,18 @@ class YQTableListViewItem : public QY2ListViewItem
 public:
 
     /**
-     * Constructor.
+     * Constructor for toplevel items.
      **/
-    YQTableListViewItem( YQTable     * 	table,
-			 QY2ListView * 	parent,
-			 YTableItem  *	origItem );
+    YQTableListViewItem( YQTable     * table,
+			 QY2ListView * parent,
+			 YTableItem  * origItem );
+
+    /**
+     * Constructor for nested items.
+     **/
+    YQTableListViewItem( YQTable             * table,
+			 YQTableListViewItem * parentItemClone,
+			 YTableItem          * origItem );
 
     /**
      * Return the parent table widget.
@@ -220,6 +241,11 @@ public:
      * Update this item's display with the content of 'cell'.
      **/
     void updateCell( const YTableCell * cell );
+
+    /**
+     * Update all columns of this item with the content of the original item.
+     **/
+    void updateCells();
 
     /**
      * The text of the table cell or the sort-key if available.


### PR DESCRIPTION
# Master PR

https://github.com/libyui/libyui-old/pull/171 _Edit 2021-08-10: Link updated_

- Trello: https://trello.com/c/dC5eSlNw/1957-8-nested-tables-widget
- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1176402

**This is the Qt UI part.**

## Problem

We need nested (tree-like) items in the Table widget.

![storage-nested-1](https://user-images.githubusercontent.com/11538225/92714670-c96b1380-f35c-11ea-815f-6be35416d15b.png)

## Solution

The underlying Qt widget we are using for our YQTable widget already supports tree-like items, so the change wasn't too hard: We are now iterating over the children of the (toplevel) widgets as well to create nested items recursively.

## ~~Ivan's PR~~
~~This also includes Ivan's PR #131 which is already reviewed so we don't need another round of SO-bump PRs for all the libyui repos.~~

See https://github.com/libyui/libyui-qt/pull/132#issuecomment-700686527.

