### PR TITLE
Allow to show or hide menu items

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://EditorConfig.org  -*- ini -*-
+# This is a unified way to tell all your editors
+# about the proper indentation style in this repo.
+#
+# Emacs:   https://github.com/editorconfig/editorconfig-emacs#readme
+# Vim:     https://github.com/editorconfig/editorconfig-vim#readme
+# VS Code: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
+
+# don't continue looking in upper directories, this is the top level
+root = true
+
+[*.{h,cc}]
+indent_style = tab
+indent_size = 4
+tab_width = 8

--- a/src/YQMenuBar.cc
+++ b/src/YQMenuBar.cc
@@ -198,6 +198,30 @@ YQMenuBar::setItemEnabled( YMenuItem * item, bool enabled )
 
 
 void
+YQMenuBar::setItemVisible( YMenuItem * item, bool visible )
+{
+    QObject * qObj = static_cast<QObject *>( item->uiItem() );
+
+    if ( qObj )
+    {
+        QMenu * menu = qobject_cast<QMenu *>( qObj );
+
+        if ( menu )
+	    menu->menuAction()->setVisible( visible );
+        else
+        {
+            QAction * action = qobject_cast<QAction *>( qObj );
+
+            if ( action )
+		action->setVisible( visible );
+        }
+    }
+
+    YMenuWidget::setItemVisible( item, visible );
+}
+
+
+void
 YQMenuBar::setEnabled( bool enabled )
 {
     YWidget::setEnabled( enabled );

--- a/src/YQMenuBar.cc
+++ b/src/YQMenuBar.cc
@@ -73,19 +73,19 @@ YQMenuBar::rebuildMenuTree()
     for ( YItemIterator it = itemsBegin(); it != itemsEnd(); ++it )
     {
 	YMenuItem * item = dynamic_cast<YMenuItem *>( *it );
-        YUI_CHECK_PTR( item );
+	YUI_CHECK_PTR( item );
 
-        if ( ! item->isMenu() )
-            YUI_THROW( YUIException( "YQMenuBar: Only menus allowed on toplevel." ) );
+	if ( ! item->isMenu() )
+	    YUI_THROW( YUIException( "YQMenuBar: Only menus allowed on toplevel." ) );
 
-        QMenu * menu = QMenuBar::addMenu( fromUTF8( item->label() ));
-        item->setUiItem( menu );
+	QMenu * menu = QMenuBar::addMenu( fromUTF8( item->label() ));
+	item->setUiItem( menu );
 
-        connect( menu, &pclass(menu)::triggered,
-                 this, &pclass(this)::menuEntryActivated );
+	connect( menu, &pclass(menu)::triggered,
+		this, &pclass(this)::menuEntryActivated );
 
-        // Recursively add menu content
-        rebuildMenuTree( menu, item->childrenBegin(), item->childrenEnd() );
+	// Recursively add menu content
+	rebuildMenuTree( menu, item->childrenBegin(), item->childrenEnd() );
     }
 }
 
@@ -96,20 +96,20 @@ YQMenuBar::rebuildMenuTree( QMenu * parentMenu, YItemIterator begin, YItemIterat
     for ( YItemIterator it = begin; it != end; ++it )
     {
 	YMenuItem * item = dynamic_cast<YMenuItem *>( *it );
-        YUI_CHECK_PTR( item );
+	YUI_CHECK_PTR( item );
 	QIcon icon;
 
 	if ( item->hasIconName() )
 	    icon = YQUI::ui()->loadIcon( item->iconName() );
 
-        if ( item->isSeparator() )
-        {
-            parentMenu->addSeparator();
-        }
+	if ( item->isSeparator() )
+	{
+	    parentMenu->addSeparator();
+	}
 	else if ( item->isMenu() )
 	{
 	    QMenu * subMenu = parentMenu->addMenu( fromUTF8( item->label() ));
-            item->setUiItem( subMenu );
+	    item->setUiItem( subMenu );
 
 	    if ( ! icon.isNull() )
 		subMenu->setIcon( icon );
@@ -121,12 +121,12 @@ YQMenuBar::rebuildMenuTree( QMenu * parentMenu, YItemIterator begin, YItemIterat
 	}
 	else // Plain menu item (leaf item)
 	{
-            QAction * action = parentMenu->addAction( fromUTF8( item->label() ) );
-            item->setUiItem( action );
-            _actionMap[ action ] = item;
+	    QAction * action = parentMenu->addAction( fromUTF8( item->label() ) );
+	    item->setUiItem( action );
+	    _actionMap[ action ] = item;
 
-            if ( ! icon.isNull() )
-                action->setIcon( icon );
+	    if ( ! icon.isNull() )
+		action->setIcon( icon );
 	}
     }
 }
@@ -136,11 +136,11 @@ void
 YQMenuBar::menuEntryActivated( QAction * action )
 {
     if ( _actionMap.contains( action ) )
-         _selectedItem = _actionMap[ action ];
+	 _selectedItem = _actionMap[ action ];
 
     if ( _selectedItem )
     {
-        // yuiDebug() << "Selected menu entry \"" << fromUTF8( _selectedItem->label() ) << "\"" << endl;
+	// yuiDebug() << "Selected menu entry \"" << fromUTF8( _selectedItem->label() ) << "\"" << endl;
 
 	/*
 	 * Defer the real returnNow() until all popup related events have been
@@ -180,17 +180,17 @@ YQMenuBar::setItemEnabled( YMenuItem * item, bool enabled )
 
     if ( qObj )
     {
-        QMenu * menu = qobject_cast<QMenu *>( qObj );
+	QMenu * menu = qobject_cast<QMenu *>( qObj );
 
-        if ( menu )
-            menu->setEnabled( enabled );
-        else
-        {
-            QAction * action = qobject_cast<QAction *>( qObj );
+	if ( menu )
+	    menu->setEnabled( enabled );
+	else
+	{
+	    QAction * action = qobject_cast<QAction *>( qObj );
 
-            if ( action )
-                action->setEnabled( enabled );
-        }
+	    if ( action )
+		action->setEnabled( enabled );
+	}
     }
 
     YMenuWidget::setItemEnabled( item, enabled );
@@ -204,17 +204,17 @@ YQMenuBar::setItemVisible( YMenuItem * item, bool visible )
 
     if ( qObj )
     {
-        QMenu * menu = qobject_cast<QMenu *>( qObj );
+	QMenu * menu = qobject_cast<QMenu *>( qObj );
 
-        if ( menu )
+	if ( menu )
 	    menu->menuAction()->setVisible( visible );
-        else
-        {
-            QAction * action = qobject_cast<QAction *>( qObj );
+	else
+	{
+	    QAction * action = qobject_cast<QAction *>( qObj );
 
-            if ( action )
+	    if ( action )
 		action->setVisible( visible );
-        }
+	}
     }
 
     YMenuWidget::setItemVisible( item, visible );
@@ -260,7 +260,7 @@ void
 YQMenuBar::activateItem( YMenuItem * item )
 {
     if ( item )
-        YQUI::ui()->sendEvent( new YMenuEvent( item ) );
+	YQUI::ui()->sendEvent( new YMenuEvent( item ) );
 }
 
 

--- a/src/YQMenuBar.h
+++ b/src/YQMenuBar.h
@@ -52,7 +52,7 @@ public:
     /**
      * Rebuild the displayed menu tree from the internally stored YMenuItems.
      *
-     * Implemented from YMenuBar.
+     * Implemented from YMenuWidget.
      **/
     virtual void rebuildMenuTree();
 
@@ -95,6 +95,13 @@ public:
      * Reimplemented from YMenuWidget.
      **/
     virtual void setItemEnabled( YMenuItem * item, bool enabled );
+
+    /**
+     * Show or hide an item.
+     *
+     * Reimplemented from YMenuWidget.
+     **/
+    virtual void setItemVisible( YMenuItem * item, bool visible );
 
     /**
      * Activate the item selected in the tree. Can be used in tests to simulate


### PR DESCRIPTION
Note: This PR is going to be merged into *sprint-108* branch instead of master. There are some WIP features (i.e., nesting tables) and they all will be merged together into master to bump so versions only once.

See https://github.com/libyui/libyui/pull/172.

#### Changes

The *sprint-108* branch is accumulating several new features. The plan is to merge them all into master and bump the so versions only once. At that time, we will provide an entry in the *changes* file. Here is a proposal for that changes entry:

~~~
* Resolve hotkeys conflicts for widgets with multiple hotkeys
  (related to bsc#1175489).
* Allow to show/hide menus and menu items (related to
  manatools/libyui-mga#1).
* Allow nested items in tables (bsc#1176402).
~~~