### PR TITLE
cmake: do not create the include symlink if it already exists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,9 +202,13 @@ set( LOCAL_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include )
 # Symlink ../../libyui/src to build/src/include/yui
 # so the headers there can be included as <yui/YFoo.h>
 add_custom_target( local-include-dir
-  COMMAND rm -rf ${LOCAL_INCLUDE_DIR}
-  COMMAND mkdir  ${LOCAL_INCLUDE_DIR}
-  COMMAND ln -s  ${CMAKE_CURRENT_SOURCE_DIR}/../../libyui/src ${LOCAL_INCLUDE_DIR}/yui )
+  # check if the symlink already exists
+  COMMAND if [ ! -L "${LOCAL_INCLUDE_DIR}/yui" ]\; then
+      rm -rf ${LOCAL_INCLUDE_DIR}\;
+      mkdir  ${LOCAL_INCLUDE_DIR}\;
+      ln -s  ${CMAKE_CURRENT_SOURCE_DIR}/../../libyui/src ${LOCAL_INCLUDE_DIR}/yui\;
+    fi
+  )
 
 add_dependencies( ${TARGETLIB} local-include-dir )
 target_include_directories( ${TARGETLIB} BEFORE PUBLIC ${LOCAL_INCLUDE_DIR} )


### PR DESCRIPTION
- The same fix as in https://github.com/libyui/libyui-ncurses/pull/113
- Running `sudo make install` created the symlink as `root`, the next `make` call failed when trying to re-create the symlink.
- As this is only for developers no need for version bump or package submission